### PR TITLE
Alsace moselle

### DIFF
--- a/example-integration.html
+++ b/example-integration.html
@@ -6,9 +6,28 @@
 		<meta name="viewport" content="initial-scale=1">
 		<title>Intégrateur numéro 1</title>
 	</head>
+	<style>
+		#en-tête {
+			text-align: center;
+			border: 1px solid #333;
+			padding: 1em;
+			width: 100%;
+			margin: 0 auto;
+		}
+
+		#module {
+
+		}
+	</style>
 
 	<body>
-		<script id="script-simulateur-embauche" src="dist/simulateur.js" data-couleur="#4A89DC"></script>
+		<section id="en-tête">
+			<h1>Ma page Web</h1>
+			<p>Gagnez en visibilité sur le prix d'une embauche en France !</p>
+		</section>
+		<section id="module">
+			<script id="script-simulateur-embauche" src="dist/simulateur.js" data-couleur="#333"></script>
+		</section>
 		<!-- #1F4382 - #3570B8 - #4A89DC - #4A9DED-->
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cout-embauche",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",

--- a/source/containers/Conversation.js
+++ b/source/containers/Conversation.js
@@ -39,7 +39,7 @@ class Conversation extends Component {
 					name="codeINSEE" />
 				<Input
 					title="Complémentaire santé"
-					question="Quel est le montant total par salarié de votre complémentaire santé entreprise obligatoire ?"
+					question="Quel est le montant total par salarié de la complémentaire santé obligatoire de l'entreprise ?"
 					visible={effectifEntreprise < 10 || steps.get('codeINSEE')}
 					name="mutuelle" />
 				<Group

--- a/source/containers/Conversation.js
+++ b/source/containers/Conversation.js
@@ -42,7 +42,6 @@ class Conversation extends Component {
 					question="Quel est le montant total par salarié de votre complémentaire santé entreprise obligatoire ?"
 					visible={effectifEntreprise < 10 || steps.get('codeINSEE')}
 					name="mutuelle" />
-
 				<Group
 					text="Risques professionnels"
 					visible={steps.get('mutuelle')}
@@ -81,11 +80,17 @@ class Conversation extends Component {
 					name="pourcentage_alternants" />
 
 				<Question
-					title="Exonération Jeune Entreprise Innovante"
-					question="Profitez-vous du statut Jeune Entreprise Innovante pour cette embauche ?"
 					visible={
 						(effectifEntreprise < 249 && steps.get('tauxRisque'))
 						|| steps.get('pourcentage_alternants')}
+					title="Régime Alsace-Moselle"
+					question="Le salarié est-il affilié au régime d'Alsace-Moselle ?"
+					name="alsaceMoselle" />
+
+				<Question
+					title="Exonération Jeune Entreprise Innovante"
+					question="Profitez-vous du statut Jeune Entreprise Innovante pour cette embauche ?"
+					visible={steps.get('alsaceMoselle')}
 					name="jei" />
 
 				<Question

--- a/source/conversation-steps.js
+++ b/source/conversation-steps.js
@@ -100,6 +100,15 @@ export default {
 		adapt: (raw, validated) => ({'complementaire_sante_montant': validated}),
 	},
 
+	'alsaceMoselle': {
+		choices: [ 'Oui', 'Non' ],
+		helpText:
+		<p>
+			Cette affiliation est obligatoire si l'activité est exercée dans les départements du Bas-Rhin, du Haut-Rhin et de la Moselle. Elle l'est aussi dans certains autres cas, expliqués sur <a href="http://regime-local.fr/salaries/" target="_blank">cette page.</a>
+			<br/>
+		</p>,
+		adapt: raw => ({salarie_regime_alsace_moselle: raw === 'Oui' ? 1 : 0}),
+	},
 
 	'codeINSEE': {
 		defaultValue: {codeInsee: '29019', nomCommune: 'Ville de 100 000 habitants'},


### PR DESCRIPTION
Ajout d'une question sur le régime d'Alsace-Moselle.
Dépend du déploiement de openfisca/openfisca-france/pull/624 :white_check_mark: 

Autres : 
- ajout d'un style basique sur l'example d'intégration
- reformulation de la question complémentaire santé