### PR TITLE
Use an absolute link for the SGMAP logo

### DIFF
--- a/source/components/Affiliation.js
+++ b/source/components/Affiliation.js
@@ -7,7 +7,7 @@ export default () =>
 			<img alt="OpenFisca" src="https://www.openfisca.fr/hotlinks/logo-openfisca.svg" />
 		</a>
     <a href="https://beta.gouv.fr" target="_blank">
-      <img id="logo-SGMAP" alt="Secrétariat Général pour la Modernisation de l'Action Publique" src={require('../images/logo-SGMAP.svg')} />
+      <img id="logo-SGMAP" alt="Secrétariat Général pour la Modernisation de l'Action Publique" src="https://embauche.beta.gouv.fr/simulateur/source/images/logo-SGMAP.svg" />
     </a>
 		<a id="affiliation-contact" href="mailto:contact@embauche.beta.gouv.fr?subject=A propos du simulateur d'embauche">contact</a>
   </section>


### PR DESCRIPTION
The /simulateur prefix prevents refering to the correct image url