### PR TITLE
Improve affiliation source specificity

### DIFF
--- a/source/components/Affiliation.js
+++ b/source/components/Affiliation.js
@@ -3,7 +3,7 @@ import './Affiliation.css'
 
 export default () =>
 	<section id="affiliation">
-		<a href="https://openfisca.fr" target="_blank">
+		<a href="https://openfisca.fr?utm_source=affiliation&utm_campaign=widget_embauche" target="_blank">
 			<img alt="OpenFisca" src="https://www.openfisca.fr/hotlinks/logo-openfisca.svg" />
 		</a>
     <a href="https://beta.gouv.fr" target="_blank">


### PR DESCRIPTION
openfisca.fr does get some traffic from different places thanks to this widget. However, it is not easy to identify at a glance that this is thanks to this inclusion. This change would allow the OpenFisca team to assess more precisely the impact of the Embauche Widget as a traffic entry.