### PR TITLE
Ajout du lien vers le simulateur CDD en beta

### DIFF
--- a/source/components/InfoZone.js
+++ b/source/components/InfoZone.js
@@ -4,36 +4,52 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 export default ({
 	showAdvanced, toggleAdvancedSection,
 	inputTouched, inputChanged,
-	infoAlternance, themeColours: {textColourOnWhite},
+	infoNonCDI, themeColours: {textColourOnWhite},
 	pending
 }) =>
 <section className="info-zone">
-	{ !showAdvanced &&
-		<ReactCSSTransitionGroup
-			id="user-next-action"
-			component="div"
-			transitionName="user-next-action-animation"
-			transitionEnterTimeout={10000}
-			transitionLeaveTimeout={700} >
-			{ !inputTouched && !inputChanged &&
-				<div key="1" className="input-tip">
-					<p>Renseignez votre situation ci-dessus</p>
-				</div>
+	{	infoNonCDI ?
+		<p className="infoNonCDI" style={{color: textColourOnWhite}}>
+			{ infoNonCDI == 'apprenti' && <span>
+					Pour une simulation d'embauche en apprentissage, rendez-vous sur <a href="https://www.alternance.emploi.gouv.fr/portail_alternance/jcms/hl_6238/simulateur-alternant" target="_blank">
+						le simulateur du portail de l'alternance
+					</a>.
+				</span>
 			}
-			{ inputChanged &&
-				<div key="2" className="input-tip">
-					<p>Votre estimation est mise à jour à chaque changement</p>
-					<p>Pour des résultats plus précis,&nbsp;
-						<a href="#" style={{color: textColourOnWhite}}
-						id="show-advanced"
-						onClick={toggleAdvancedSection}
-						title="Allez plus loin dans l'estimation avec quelques questions supplémentaires">
-						affinez votre situation
-					</a> (moins de 10 questions)
-					</p>
-				</div>
+			{ infoNonCDI == 'CDD' && <span>
+					Pour une simulation d'embauche en CDD, rendez-vous sur <a href="https://embauche.beta.gouv.fr/simu/surco%C3%BBt-CDD/intro" target="_blank">
+						notre simulateur en version <em>beta</em>
+					</a>.
+				</span>
 			}
-		</ReactCSSTransitionGroup>
+		</p>
+	: (
+		!showAdvanced &&
+			<ReactCSSTransitionGroup
+				id="user-next-action"
+				component="div"
+				transitionName="user-next-action-animation"
+				transitionEnterTimeout={10000}
+				transitionLeaveTimeout={700} >
+				{ !inputTouched && !inputChanged &&
+					<div key="1" className="input-tip">
+						<p>Renseignez votre situation ci-dessus</p>
+					</div>
+				}
+				{ inputChanged &&
+					<div key="2" className="input-tip">
+						<p>Votre estimation est mise à jour à chaque changement</p>
+						<p>Pour des résultats plus précis,&nbsp;
+							<a href="#" style={{color: textColourOnWhite}}
+							id="show-advanced"
+							onClick={toggleAdvancedSection}
+							title="Allez plus loin dans l'estimation avec quelques questions supplémentaires">
+							affinez votre situation
+						</a> (moins de 10 questions)
+						</p>
+					</div>
+				}
+			</ReactCSSTransitionGroup>)
 	}
 	{ showAdvanced &&
 		<a href="#"
@@ -42,13 +58,6 @@ export default ({
 		title="Réinitialiser les questions supplémentaires">
 		Réinitialiser
 		</a>
-	}
-	{	infoAlternance &&
-		<p className="alternance">
-			Note: pour une simulation plus fiable du cas de l'apprentissage, rendez-vous sur <a href="https://www.alternance.emploi.gouv.fr/portail_alternance/jcms/hl_6238/simulateur-alternant" target="_blank">
-				le simulateur du portail de l'alternance
-			</a>
-		</p>
 	}
 	{
 		typeof pending == 'string' &&

--- a/source/containers/BasicInput.js
+++ b/source/containers/BasicInput.js
@@ -45,6 +45,7 @@ export default class BasicInput extends Component {
 				&nbsp; souhaite embaucher un·e
 				<Field component="select" name="typeEmployé" >
 					<option value="CDI">CDI</option>
+					<option value="CDD">CDD</option>
 					<option value="apprenti">apprenti·e</option>
 				</Field>
 

--- a/source/containers/Widget.js
+++ b/source/containers/Widget.js
@@ -11,7 +11,7 @@ let selector = formValueSelector('basicInput')
 @connect(state => ({
 	activeSection: state.activeSections.top,
 	showAdvanced: state.activeSections.advanced,
-	infoAlternance: selector(state, 'typeEmployé') == 'apprenti',
+	infoNonCDI: selector(state, 'typeEmployé') === 'CDI' ? false : selector(state, 'typeEmployé'),
 	inputTouched: state.form.basicInput && (
 		state.form.basicInput.active || state.form.basicInput.anyTouched),
 	inputChanged: state.inputChanged
@@ -26,7 +26,7 @@ export default class Widget extends React.Component {
 	render() {
 		let {
 			activeSection, showAdvanced, toggleAdvancedSection,
-			inputTouched, inputChanged, infoAlternance
+			inputTouched, inputChanged, infoNonCDI
 		} = this.props
 		return (
 				<div className="widget">
@@ -36,9 +36,10 @@ export default class Widget extends React.Component {
 						toggleAdvancedSection={toggleAdvancedSection}
 						inputTouched={inputTouched}
 						inputChanged={inputChanged}
-						infoAlternance={infoAlternance}
+						infoNonCDI={infoNonCDI}
 					/>
-					<Results showDetails={activeSection == 'details'}/>
+					{!infoNonCDI &&
+						<Results showDetails={activeSection == 'details'}/> }
 					<Affiliation />
 				</div>
 		)

--- a/source/containers/advanced-questions.css
+++ b/source/containers/advanced-questions.css
@@ -315,8 +315,13 @@ fieldset > .ignore {
 	margin: .1em;
 }
 
-.alternance {
-	font-weight: bold
+.infoNonCDI {
+	margin: 3em auto;
+	font-size: 140%;
+}
+.infoNonCDI a {
+	color: inherit;
+	font-weight: 600;
 }
 
 .error {

--- a/source/details-spec.yaml
+++ b/source/details-spec.yaml
@@ -170,8 +170,6 @@ Détails:
       Autres allègements employeur:
         Jeune entreprise innovante:
           employeur: exoneration_cotisations_employeur_jei
-        Exonérations pour l'apprentissage:
-          employeur: exoneration_cotisations_employeur_apprenti
 
       ####################################################################################
 

--- a/source/outputVariables.yaml
+++ b/source/outputVariables.yaml
@@ -114,8 +114,6 @@ Aides employeur immédiates:
     name: Réduction de cotisation d’allocations familiales
   - key: exoneration_cotisations_employeur_jei
     name: Jeune entreprise innovante
-  - key: exoneration_cotisations_employeur_apprenti
-    name: Exonérations pour l'apprentissage
 
 Aides employeur différées:
 

--- a/source/sagas.js
+++ b/source/sagas.js
@@ -21,7 +21,7 @@ function* handleFormChange(e) {
 	let {meta} = e,
 		field = meta && meta.field
 
-	if (field && !steps[field].adapt) {
+	if (field && (!steps[field] || !steps[field].adapt)) {
 		// This change doesn't impact the Web API call
 		return
 	}


### PR DESCRIPTION
À la sélection du type de contrat CDD, on affiche un message redirigeant
vers le simulateur CDD, et on cache le reste.
Même comportement pour l'apprenti : on ne le simule plus du tout.